### PR TITLE
Update HPA to autoscaling/v2

### DIFF
--- a/plumber-cluster/Chart.yaml
+++ b/plumber-cluster/Chart.yaml
@@ -20,9 +20,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.18.0
+appVersion: 2.6.1

--- a/plumber-cluster/templates/hpa.yaml
+++ b/plumber-cluster/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "plumber.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Updates the HPA object to `autoscaling/v2` as `autoscaling/v2beta1` [is deprecated](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125).  Without this update, autoscaling will fail in k8s clusters using version 1.25 or greater with an error like this:

```
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "plumber-plumber-cluster" namespace: "" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
  ensure CRDs are installed first
```

<details>
<summary>Example helm diff</summary>

relevant values.yml settings:
```yaml
autoscaling:
  enabled: true
  minReplicas: 3
  maxReplicas: 20
  targetCPUUtilizationPercentage: 90
```

diff:
```yaml
+ # Source: plumber-cluster/templates/hpa.yaml
+ apiVersion: autoscaling/v2
+ kind: HorizontalPodAutoscaler
+ metadata:
+   name: plumber-plumber-cluster
+   labels:
+     helm.sh/chart: plumber-cluster-3.0.0
+     app.kubernetes.io/name: plumber-cluster
+     app.kubernetes.io/instance: plumber
+     app.kubernetes.io/version: "2.6.1"
+     app.kubernetes.io/managed-by: Helm
+ spec:
+   scaleTargetRef:
+     apiVersion: apps/v1
+     kind: Deployment
+     name: plumber-plumber-cluster
+   minReplicas: 3
+   maxReplicas: 20
+   metrics:
+     - type: Resource
+       resource:
+         name: cpu
+         target:
+           type: Utilization
+           averageUtilization: 90
```

produces an hpa like so:
```
❯ k get hpa
NAME                      REFERENCE                            TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
plumber-plumber-cluster   Deployment/plumber-plumber-cluster   31%/90%   3         20        3          5m45s
```
</details>